### PR TITLE
Only get themes that use the first version of the engine

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -64,8 +64,8 @@ Fliplet.Widget.register('com.fliplet.theme', function() {
         url: [
           'v1/widgets?include_instances=true&tags=type:theme',
           '&include_all_versions=true',
-          '&appId=' + F.Env.get('appId'),
-          '&organizationId=' + F.Env.get('organizationId')
+          '&appId=' + Fliplet.Env.get('appId'),
+          '&organizationId=' + Fliplet.Env.get('organizationId')
         ].join('')
       }).then(function (response) {
         // Only get themes that use the first version of the engine

--- a/js/interface.js
+++ b/js/interface.js
@@ -60,10 +60,25 @@ Fliplet.Widget.register('com.fliplet.theme', function() {
     }
 
     if (!themesLoadingPromise) {
-      themesLoadingPromise = Fliplet.Themes.get().then(function (response) {
+      themesLoadingPromise = Fliplet.API.request({
+        url: [
+          'v1/widgets?include_instances=true&tags=type:theme',
+          '&include_all_versions=true',
+          '&appId=' + F.Env.get('appId'),
+          '&organizationId=' + F.Env.get('organizationId')
+        ].join('')
+      }).then(function (response) {
+        // Only get themes that use the first version of the engine
+        var themeWidgets = response.widgets;
+        themeWidgets = _.values(_.groupBy(themeWidgets, 'package')).map((packageWidgets) => {
+          return _.find(packageWidgets, (widget) => {
+            return widget.tags.indexOf('engineVersion:2') === -1;
+          });
+        });
+
         themesLoadingPromise = null;
-        themes = response;
-        return themes;
+        themes = themeWidgets;
+        return themeWidgets;
       });
     }
 


### PR DESCRIPTION
- Updated first version of theme manager to only get themes without the `engineVersion:2` tag.