### PR TITLE
Fix 4583

### DIFF
--- a/dist/css/index.css
+++ b/dist/css/index.css
@@ -316,6 +316,7 @@ header {
     justify-content: center;
     z-index: 1000;
     min-width: 200px;
+    max-width: 200px;
     margin-top: 5px;
     margin-bottom: 5px;
     padding: 13px 20px 9px;

--- a/src/scss/base/base.scss
+++ b/src/scss/base/base.scss
@@ -409,6 +409,7 @@ header {
     justify-content: center;
     z-index: 1000;
     min-width: 200px;
+    max-width: 200px;
     margin-top: 5px;
     margin-bottom: 5px;
     padding: 13px 20px 9px;


### PR DESCRIPTION
Fixes the following:
- https://github.com/Fliplet/fliplet-studio/issues/4583

Adding a `max-width` to prevent the panel from getting too big on IE11.
(On other browsers it wraps automatically because of the `display: flex`, but not on IE11)