### PR TITLE
GA tracking added and copy tweak

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -193,7 +193,7 @@ Fliplet.Widget.register('com.fliplet.theme', function() {
   $(document).on('click', '.update-theme', function() {
     Fliplet.Modal.confirm({
       title: 'Upgrade appearance settings',
-      message: '<p>The new appearance settings will give you more settings for configuration. Your current settings will not be changed.</p><p class="text-warning"><strong>Warning:</strong> Once upgraded you won\'t be able to go back to the previous version.</p>',
+      message: '<p>Once upgraded you will not be able to go back to the previous version, but all your current settings will not be changed or lost.</p>',
       buttons: {
         confirm: {
           label: 'Upgrade'
@@ -206,6 +206,11 @@ Fliplet.Widget.register('com.fliplet.theme', function() {
 
       Fliplet.App.Settings.set({ themeEngineVersion: '2.0.0' })
         .then(function() {
+          Fliplet.Analytics.trackEvent({
+            category: 'theme_manager',
+            action: 'upgrade_theme'
+          });
+
           Fliplet.Studio.emit('reload-studio');
         });
     })

--- a/js/interface.js
+++ b/js/interface.js
@@ -206,7 +206,7 @@ Fliplet.Widget.register('com.fliplet.theme', function() {
 
       Fliplet.App.Settings.set({ themeEngineVersion: '2.0.0' })
         .then(function() {
-          Fliplet.Analytics.trackEvent({
+          Fliplet.Studio.emit('track-event', {
             category: 'theme_manager',
             action: 'upgrade_theme'
           });


### PR DESCRIPTION
Tracking the following:
- User upgrades to v2

Also the copy on the pop-up now looks like this:
<img width="631" alt="Screenshot 2019-06-26 at 22 49 29" src="https://user-images.githubusercontent.com/7046481/60217469-b0b03400-9864-11e9-8133-b492ddfc3ace.png">

This change hopefully doesn't cause fear, we don't repeat the message seen on the component, and we warn the user and let them know that everything is going to be fine.
