### PR TITLE
Set 5 minute delay before color picker closing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2144,9 +2144,9 @@
       "dev": true
     },
     "codemirror-colorpicker": {
-      "version": "1.9.50",
-      "resolved": "https://registry.npmjs.org/codemirror-colorpicker/-/codemirror-colorpicker-1.9.50.tgz",
-      "integrity": "sha512-akaFf3rxHngmFfXLeO+Eqx/OiRO7hOB1aNUoT7xzJQwyvIETqcot/TzJ93SWhu9o7rj9KINWl3IT05g6qwS2+Q=="
+      "version": "1.9.66",
+      "resolved": "https://registry.npmjs.org/codemirror-colorpicker/-/codemirror-colorpicker-1.9.66.tgz",
+      "integrity": "sha512-wI4qLOzJ49Zs8jyVb/6eDdS02cd7Wi8NUb6QGSG8Ej6zmYbflttlBOLAD9Ywb0b1iSLpD1CV+eht/66f3KrKWg=="
     },
     "collection-map": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "gulp build"
   },
   "dependencies": {
-    "codemirror-colorpicker": "^1.9.50",
+    "codemirror-colorpicker": "^1.9.66",
     "core-js": "^3.1.4",
     "js-cookie": "^2.2.0",
     "regenerator-runtime": "^0.13.2",

--- a/src/components/fields/ColorField.vue
+++ b/src/components/fields/ColorField.vue
@@ -101,7 +101,8 @@ export default {
 
       this.colorpicker.show({
         left: target.left,
-        top: target.bottom
+        top: target.bottom,
+        hideDelay: 300000
       }, this.valueToShow, this.onColorChange, this.onColorChanged)
 
       this.checkTransparency()


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4972

## Description
Set 5 minute delay before color picker closing

## Backward compatibility

This change is fully backward compatible.

## Notes
We are setting the close delay to the 5 minutes because we can't remove it completely duo an issue within a codemirror-colorpicker at this [line](https://github.com/easylogic/codemirror-colorpicker/blob/79c3c68a901de561bb1f34967c8692456c6ecaeb/src/colorpicker/BaseColorPicker.js#L270). It works that if we set `0` like their documentation says we won't disable a set timeout as they say but we will set timeout with 0. 